### PR TITLE
Removed Docker-build-test from needs in main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
 
   Deployment:
     needs:
-      - Docker-functional-testing
       - Testing
     uses: ./.github/workflows/deployment.yml
     secrets:


### PR DESCRIPTION
Deployment already waits for Testing, so it cannot wait for nested jobs inside Testing